### PR TITLE
have bundle build cnats

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/cnats"]
+	path = vendor/cnats
+	url = git@github.com:nats-io/cnats.git

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+import "ext/ffi/nats/core/Rakefile"
 
 namespace :cnats do
   desc "build cnats"
   task :compile do
-    load "ext/ffi/nats/core/Rakefile"
+    Rake::Task[:compile_cnats].invoke
   end
 
   desc "checkout cnats source"

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ namespace :cnats do
 
   desc "checkout cnats source"
   task :checkout do
-    puts ::File.directory?("vendor/cnats/build")
     unless ::File.directory?("vendor/cnats/build")
       sh "git submodule update --init"
     end

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,27 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+namespace :cnats do
+  desc "build cnats"
+  task :compile do
+    load "ext/ffi/nats/core/Rakefile"
+  end
+
+  desc "checkout cnats source"
+  task :checkout do
+    puts ::File.directory?("vendor/cnats/build")
+    unless ::File.directory?("vendor/cnats/build")
+      sh "git submodule update --init"
+    end
+  end
+end
+Rake::Task["cnats:compile"].prerequisites.insert(0, "cnats:checkout")
+
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb']
 end
+Rake::Task[:test].prerequisites << "cnats:compile"
 
 task :default => :test

--- a/ext/ffi/nats/core/Rakefile
+++ b/ext/ffi/nats/core/Rakefile
@@ -46,7 +46,7 @@ CWD = ::File.expand_path(::File.dirname(__FILE__))
 CNATS_DIR = ::File.join(CWD, "..", "..", "..", "..", "vendor", "cnats")
 
 ::Dir.chdir(CNATS_DIR) do
-  ::Dir.mkdir("build") if !Dir.exists?("build")
+  ::Dir.mkdir("build") unless ::Dir.exists?("build")
 
   ::Dir.chdir("build") do
     sys("cmake ..")

--- a/ext/ffi/nats/core/Rakefile
+++ b/ext/ffi/nats/core/Rakefile
@@ -1,0 +1,74 @@
+require "rubygems"
+require "fileutils"
+require "ffi"
+
+# Copied fom mkmf
+def find_executable(bin, path = nil)
+  executable_file = proc do |name|
+    begin
+      stat = File.stat(name)
+    rescue SystemCallError
+    else
+      next name if stat.file? and stat.executable?
+    end
+  end
+
+  exts = config_string('EXECUTABLE_EXTS') {|s| s.split} || config_string('EXEEXT') {|s| [s]}
+  if File.expand_path(bin) == bin
+    return bin if executable_file.call(bin)
+    if exts
+      exts.each {|ext| executable_file.call(file = bin + ext) and return file}
+    end
+    return nil
+  end
+  if path ||= ENV['PATH']
+    path = path.split(File::PATH_SEPARATOR)
+  else
+    path = %w[/usr/local/bin /usr/ucb /usr/bin /bin]
+  end
+  file = nil
+  path.each do |dir|
+    return file if executable_file.call(file = File.join(dir, bin))
+    if exts
+      exts.each {|ext| executable_file.call(ext = file + ext) and return ext}
+    end
+  end
+  nil
+end
+
+
+def sys(cmd)
+  puts " -- #{cmd}"
+  unless ret = system(cmd)
+    raise "ERROR: '#{cmd}' failed"
+  end
+  ret
+end
+
+if !find_executable("cmake")
+  abort "ERROR: CMake is required to build ffi-nats-core."
+end
+
+CWD = ::File.expand_path(::File.dirname(__FILE__))
+CNATS_DIR = ::File.join(CWD, "..", "..", "..", "..", "vendor", "cnats")
+
+::Dir.chdir(CNATS_DIR) do
+  ::Dir.mkdir("build") if !Dir.exists?("build")
+
+  ::Dir.chdir("build") do
+    sys("cmake ..")
+    sys("make nats")
+  end
+end
+
+unless ::File.exist?(::File.join(CNATS_DIR, "build", "libnats.#{::FFI::Platform::LIBSUFFIX}"))
+  abort "ERROR: Failed to build nats"
+end
+
+# This is normally set by calling create_makefile() but we don't need that
+# method since we'll provide a dummy Makefile. Without setting this value
+# RubyGems will abort the installation.
+$makefile_created = true
+$extkm = true
+
+create_makefile("ffi/nats/core")

--- a/ext/ffi/nats/core/Rakefile
+++ b/ext/ffi/nats/core/Rakefile
@@ -13,12 +13,8 @@ def find_executable(bin, path = nil)
     end
   end
 
-  exts = config_string('EXECUTABLE_EXTS') {|s| s.split} || config_string('EXEEXT') {|s| [s]}
   if File.expand_path(bin) == bin
     return bin if executable_file.call(bin)
-    if exts
-      exts.each {|ext| executable_file.call(file = bin + ext) and return file}
-    end
     return nil
   end
   if path ||= ENV['PATH']
@@ -29,9 +25,6 @@ def find_executable(bin, path = nil)
   file = nil
   path.each do |dir|
     return file if executable_file.call(file = File.join(dir, bin))
-    if exts
-      exts.each {|ext| executable_file.call(ext = file + ext) and return ext}
-    end
   end
   nil
 end
@@ -61,14 +54,6 @@ CNATS_DIR = ::File.join(CWD, "..", "..", "..", "..", "vendor", "cnats")
   end
 end
 
-unless ::File.exist?(::File.join(CNATS_DIR, "build", "libnats.#{::FFI::Platform::LIBSUFFIX}"))
+unless ::File.exist?(::File.join(CNATS_DIR, "build", "src", "libnats.#{::FFI::Platform::LIBSUFFIX}"))
   abort "ERROR: Failed to build nats"
 end
-
-# This is normally set by calling create_makefile() but we don't need that
-# method since we'll provide a dummy Makefile. Without setting this value
-# RubyGems will abort the installation.
-$makefile_created = true
-$extkm = true
-
-create_makefile("ffi/nats/core")

--- a/ext/ffi/nats/core/Rakefile
+++ b/ext/ffi/nats/core/Rakefile
@@ -29,7 +29,6 @@ def find_executable(bin, path = nil)
   nil
 end
 
-
 def sys(cmd)
   puts " -- #{cmd}"
   unless ret = system(cmd)
@@ -38,22 +37,27 @@ def sys(cmd)
   ret
 end
 
-if !find_executable("cmake")
-  abort "ERROR: CMake is required to build ffi-nats-core."
-end
+desc "Build the cnats shared lib"
+task :compile_cnats do
+  if !find_executable("cmake")
+    abort "ERROR: CMake is required to build ffi-nats-core."
+  end
 
-CWD = ::File.expand_path(::File.dirname(__FILE__))
-CNATS_DIR = ::File.join(CWD, "..", "..", "..", "..", "vendor", "cnats")
+  CWD = ::File.expand_path(::File.dirname(__FILE__))
+  CNATS_DIR = ::File.join(CWD, "..", "..", "..", "..", "vendor", "cnats")
 
-::Dir.chdir(CNATS_DIR) do
-  ::Dir.mkdir("build") unless ::Dir.exists?("build")
+  ::Dir.chdir(CNATS_DIR) do
+    ::Dir.mkdir("build") unless ::Dir.exists?("build")
 
-  ::Dir.chdir("build") do
-    sys("cmake ..")
-    sys("make nats")
+    ::Dir.chdir("build") do
+      sys("cmake ..")
+      sys("make nats")
+    end
+  end
+
+  unless ::File.exist?(::File.join(CNATS_DIR, "build", "src", "libnats.#{::FFI::Platform::LIBSUFFIX}"))
+    abort "ERROR: Failed to build nats"
   end
 end
 
-unless ::File.exist?(::File.join(CNATS_DIR, "build", "src", "libnats.#{::FFI::Platform::LIBSUFFIX}"))
-  abort "ERROR: Failed to build nats"
-end
+task :default => :compile_cnats

--- a/ext/ffi/nats/core/Rakefile
+++ b/ext/ffi/nats/core/Rakefile
@@ -39,6 +39,9 @@ end
 
 desc "Build the cnats shared lib"
 task :compile_cnats do
+  # Do not attempt to install if we want to use the system nats lib
+  next if ENV.key?("NATS_USE_SYSTEM_LIB")
+
   if !find_executable("cmake")
     abort "ERROR: CMake is required to build ffi-nats-core."
   end

--- a/ffi-nats-core.gemspec
+++ b/ffi-nats-core.gemspec
@@ -17,13 +17,14 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "exe"
+  spec.extensions    = "ext/ffi/nats/core/Rakefile"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ffi"
 
   spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/ffi/nats/core.rb
+++ b/lib/ffi/nats/core.rb
@@ -51,9 +51,18 @@ module FFI
         ENV['RUBYOPT'] = rubyopt
 
         # Search for libnats in the following order...
-        NATS_LIB_PATHS = ([inside_gem] + env_path + local_path + [rbconfig_path] + [
-          '/usr/local/lib', '/opt/local/lib', homebrew_path, '/usr/lib64'
-        ]).compact.map{|path| "#{path}/libnats.#{FFI::Platform::LIBSUFFIX}"}
+        nats_lib_paths =
+          if ENV.key?("NATS_USE_SYSTEM_LIB")
+            [inside_gem] + env_path + local_path + [rbconfig_path] + [
+             '/usr/local/lib', '/opt/local/lib', homebrew_path, '/usr/lib64'
+            ]
+          else
+            ["../../../vendor/cnats/build/src"]
+          end
+
+        NATS_LIB_PATHS = nats_lib_paths.
+          compact.map{|path| "#{path}/libnats.#{FFI::Platform::LIBSUFFIX}"}
+
         ffi_lib(NATS_LIB_PATHS + %w{libnats})
 
       rescue LoadError => error

--- a/lib/ffi/nats/core.rb
+++ b/lib/ffi/nats/core.rb
@@ -27,7 +27,8 @@ module FFI
       begin
         # bias the library discovery to a path inside the gem first, then
         # to the usual system paths
-        inside_gem = File.join(File.dirname(__FILE__), '..', '..', '..', 'ext')
+        gem_base = File.join(File.dirname(__FILE__), '..', '..', '..')
+        inside_gem = File.join(gem_base, 'ext')
         local_path = FFI::Platform::IS_WINDOWS ? ENV['PATH'].split(';') : ENV['PATH'].split(':')
         env_path = [ ENV['NATS_LIB_PATH'] ].compact
         rbconfig_path = RbConfig::CONFIG["libdir"]
@@ -57,7 +58,7 @@ module FFI
              '/usr/local/lib', '/opt/local/lib', homebrew_path, '/usr/lib64'
             ]
           else
-            ["../../../vendor/cnats/build/src"]
+            [File.join(gem_base, "vendor/cnats/build/src")]
           end
 
         NATS_LIB_PATHS = nats_lib_paths.

--- a/test/ffi/nats/core_test.rb
+++ b/test/ffi/nats/core_test.rb
@@ -1,11 +1,4 @@
 require 'test_helper'
 
-class Ffi::Nats::CoreTest < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::Ffi::Nats::Core::VERSION
-  end
-
-  def test_it_does_something_useful
-    assert false
-  end
+class FFI::Nats::CoreTest < Minitest::Test
 end


### PR DESCRIPTION
works for mri and jruby

bundle will now run cmake and build cnats. So now instead of making everyone install libnats, which _is_ in homebrew, but it's also easy to install here. We can rip this out later but it makes things easier right now.

TODO: remove the build dir before releasing to rubygems